### PR TITLE
Fix multiplayer not working due to mismatch between mod count and sent mod list

### DIFF
--- a/ModBagman/Sources/HarmonyPatches/SoG.Game1/_Network_ParseClientMessage.cs
+++ b/ModBagman/Sources/HarmonyPatches/SoG.Game1/_Network_ParseClientMessage.cs
@@ -134,7 +134,16 @@ static class _Network_ParseClientMessage
         }
 
         var clientMods = new List<(string NameID, Version Version)>();
-        var serverMods = ModManager.Mods;
+        var serverMods = new List<Mod>();
+        
+        foreach (Mod mod in ModManager.Mods)
+        {
+            if (mod.DisableObjectCreation)
+            {
+                continue;
+            }
+            serverMods.Add(mod);
+        }
 
         int clientModCount = msg.ReadInt32();
         int serverModCount = serverMods.Count;

--- a/ModBagman/Sources/HarmonyPatches/SoG.Game1/_Network_ParseServerMessage.cs
+++ b/ModBagman/Sources/HarmonyPatches/SoG.Game1/_Network_ParseServerMessage.cs
@@ -104,8 +104,19 @@ internal class _Network_ParseServerMessage
         Program.Logger.LogDebug("Writing mod list!");
 
         msg.Write(ModBagmanMod.Instance.Version.ToString());
-
-        msg.Write(ModManager.Mods.Count);
+        
+        int sentModCount = 0;
+        
+        foreach (Mod mod in ModManager.Mods)
+        {
+            if (mod.DisableObjectCreation)
+            {
+                continue;
+            }
+            sentModCount++;
+        }
+        
+        msg.Write(sentModCount);
 
         foreach (Mod mod in ModManager.Mods)
         {


### PR DESCRIPTION
I tried to test out multiplayer, but this was sent in the log whenever a player tried to join:

    2025-02-24T17:29:08.2616371+01:00  [WRN] [ModBagman] A silent error was triggered! 
    2025-02-24T17:29:08.2616371+01:00  [WRN] [ModBagman] "System.ArgumentException: Version string portion was too short or too long.
       at System.Version.VersionResult.SetFailure(ParseFailureKind failure, String argument)
       at System.Version.TryParseVersion(String version, VersionResult& result)
       at System.Version.Parse(String input)
       at ModBagman.HarmonyPatches._Network_ParseClientMessage.CheckModListCompatibility(Boolean didVersionCheckPass, InMessage msg) in <ModBagman repo path>\ModBagman\Sources\HarmonyPatches\SoG.Game1\_Network_ParseClientMessage.cs:line 144
       at SoG.Game1._Network_ParseClientMessage_Patch0(Game1 this, InMessage msg)
    SN: 97" 

After doing a bit of investigation, I think I traced it back to here:

https://github.com/Marioalexsan/ModBagman/blob/cfa6041ac01630e456c05f573db3622ce80f53f6/ModBagman/Sources/HarmonyPatches/SoG.Game1/_Network_ParseServerMessage.cs#L108-L119

After removing the `mod.DisableObjectCreation` check, sure enough, it works.
![Image](https://github.com/user-attachments/assets/0415017a-6166-417c-90b7-608d4482987c)

I'm guessing this check was to allow client-side mods or something? But it ends up making multiplayer completely non-functional, thanks to `SoG` in the base mod list having `DisableObjectCreation` enabled.

Nevertheless, this should make multiplayer work again while allowing mods with `DisableObjectCreation` to be exempt from mod list compatibility checks.

(Or I've completely misinterpreted the meaning of the check, which is very possible.)