### PR TITLE
Fix ILRepack command in paths with spaces

### DIFF
--- a/Utils/utils.py
+++ b/Utils/utils.py
@@ -59,7 +59,7 @@ def merge_assemblies():
 
     # Use ILRepack to join all assemblies into target
     cmd = [
-        ILREPACK_PATH,
+        '"' + ILREPACK_PATH + '"',
         '/out:merged/' + TARGET_ASSEMBLY,
         '/zeropekind',
         '/union',


### PR DESCRIPTION
Ran into this error while trying to figure out why ModBagman wasn't merging correctly.

Also, some questions:

~~Should I be compiling with x86 debug? (And if so, how do I do that properly?)~~

~~I just used plain `dotnet build` with no arguments previously, which presented another problem I was running into. Whenever I build, it just goes into `bin/Debug/net472/`, not `bin/x86/Debug/net472/`. Overall, I'm just very confused in that regard. I don't even know how to build into that directory. (And what about release binaries?)~~ **Edit:** Okay, apparently it's fine if I use `dotnet build` in the solution directory. Previously I was doing it in the directory of the `.csproj` file. (I still don't really understand `.sln` files. Is there even a meaningful difference between the two methods???)

And should we add `exit(0)` onto the end? Without it, it seems to throw an error every time I compile, which is kind of annoying. Is there some reason for not having it?

I'm rather inexperienced when it comes to this sort of thing so I figured it'd be best to ask.